### PR TITLE
Fix/duplicates issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,5 +88,6 @@ def main():
 
     print(f"Output written to {args.output}")
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In this PR, I have added functionality to handle duplicate rules in the SARIF conversion process. Previously, the Python script would cause an exception if the JSON contained duplicate rule IDs. 

The update introduces a set to keep track of the rule IDs that we have encountered. If we encounter a rule ID that we have seen before, we skip it. This ensures that the rules in the SARIF output do not contain duplicates, preventing the occurrence of exceptions due to duplicate items.

Please review and provide feedback. If there are no issues, I kindly request that this be merged into the main branch. Thank you.
